### PR TITLE
Add JSS references

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,13 +1,14 @@
 Package: makemyprior
-Type: Package
 Title: Intuitive Construction of Joint Priors for Variance Parameters
-Version: 1.2.1
+Version: 1.2.2
 Authors@R: c(
-    person("Ingeborg", "Hem", email = "ingeborg.hem@ntnu.no", role = c("cre", "aut")),
-    person("Geir-Arne", "Fuglstad", role = "aut"),
-    person("Andrea", "Riebler", role = "aut") )
-Description: Tool for easy prior construction and visualization. It helps to formulates joint prior distributions for variance parameters in latent Gaussian models. The resulting prior is robust and can be created in an intuitive way. A graphical user interface (GUI) can be used to choose the joint prior, where the user can click through the model and select priors. An extensive guide is available in the GUI. The package allows for direct inference with the specified model and prior. Using a hierarchical variance decomposition, we formulate a joint variance prior that takes the whole model structure into account. In this way, existing knowledge can intuitively be incorporated at the level it applies to. Alternatively, one can use independent variance priors for each model components in the latent Gaussian model.
+    person("Ingeborg", "Hem", email = "ingeborg.hem@ntnu.no", role = c("cre", "aut"), comment = c(ORCID = "0009-0008-3229-0184")),
+    person("Geir-Arne", "Fuglstad", role = "aut", comment = c(ORCID = "0000-0003-4995-2152")),
+    person("Andrea", "Riebler", role = "aut", comment = c(ORCID = "0009-0004-3998-4032")))
+Description: Tool for easy prior construction and visualization. It helps to formulates joint prior distributions for variance parameters in latent Gaussian models. The resulting prior is robust and can be created in an intuitive way. A graphical user interface (GUI) can be used to choose the joint prior, where the user can click through the model and select priors. An extensive guide is available in the GUI. The package allows for direct inference with the specified model and prior. Using a hierarchical variance decomposition, we formulate a joint variance prior that takes the whole model structure into account. In this way, existing knowledge can intuitively be incorporated at the level it applies to. Alternatively, one can use independent variance priors for each model components in the latent Gaussian model. Details can be found in the accompanying scientific paper: Hem, Fuglstad, Riebler (2024, Journal of Statistical Software, <doi:10.18637/jss.v110.i03>).
 License: GPL (>= 2)
+URL: https://github.com/ingebogh/makemyprior
+BugReports: https://github.com/ingebogh/makemyprior/issues
 Encoding: UTF-8
 LazyData: true
 Imports: ggplot2, Matrix, methods, shiny, shinyjs, shinyBS, visNetwork,

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,0 +1,18 @@
+bibentry(bibtype = "Article",
+  title        = "{makemyprior}: Intuitive Construction of Joint Priors for Variance Parameters in {R}",
+  author       = c(person(given = "Ingeborg",
+                          family = "Hem",
+                          email = "ingeborg.hem@ntnu.no"),
+                   person(given = "Geir-Arne",
+                          family = "Fuglstad"),
+                   person(given = "Andrea",
+                          family = "Riebler")),
+  journal      = "Journal of Statistical Software",
+  year         = "2024",
+  volume       = "110",
+  number       = "3",
+  pages        = "1--39",
+  doi          = "10.18637/jss.v110.i03",
+  header       = "To cite makemyprior in publications use:"
+)
+


### PR DESCRIPTION
Ingeborg, as discussed in the JSS editorial system I have added a `CITATION` file for the upcoming JSS paper in `makemyprior`. I have also updated the "Description" in the `DESCRIPTION` file with this references.

Furthermore, I made the following improvements in the `DESCRIPTION`:

- Bump version to 1.2.2 so that the package can be submitted to CRAN.
- Include ORCIDs in the "Authors@R" field. Please check that these are correct.
- Add "URL" and "BugReports" fields using the standard GitHub links to this repository.
- Omit the obsolete "Type: Package" which is not used for anything anymore.